### PR TITLE
Display shot labels in the HTML so that you don't need to hover mouse over the Shot span

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,8 @@ require 'asciidoctor'
 require 'asciidoctor/extensions'
 
 def shot(number, title="Shot #{number}")
-  %(<span title="#{title}" style="border-radius: 10px; padding: 2px 5px 2px 5px; color: white; font-weight: bold; background-color: red; font-family: sans-serif;">Shot #{number}</span>)
+  suffix = ': ' + title if title
+  %(<span title="#{title}" style="border-radius: 10px; padding: 2px 5px 2px 5px; color: white; font-weight: bold; background-color: red; font-family: sans-serif;">Shot #{number}#{suffix}</span>)
 end
 
 class ShotInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor


### PR DESCRIPTION
The result looks like this...

![image](https://user-images.githubusercontent.com/144701/79865923-4876a400-83dc-11ea-8dbe-44d12aaa8dde.png)
